### PR TITLE
using same checkpoint directory for docker volume mapping and state.checkpoints.dir

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -41,7 +41,7 @@ services:
       - 8081:8081
     volumes:
       - ./conf:/opt/flink/conf
-      - flink-checkpoint-directory:/tmp/flink-checkpoint-directory
+      - flink-checkpoints-directory:/tmp/flink-checkpoints-directory
       - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
@@ -52,7 +52,7 @@ services:
     command: "taskmanager.sh start-foreground"
     volumes:
       - ./conf:/opt/flink/conf
-      - flink-checkpoint-directory:/tmp/flink-checkpoint-directory
+      - flink-checkpoints-directory:/tmp/flink-checkpoints-directory
       - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
@@ -70,4 +70,4 @@ services:
     ports:
       - 9094:9094
 volumes:
-  flink-checkpoint-directory:
+  flink-checkpoints-directory:


### PR DESCRIPTION
This PR fixes a minor typo for the checkpoint volume mapping in *docker-compose.yaml*.

While *flink-conf.yaml* uses this config:
```
state.checkpoints.dir: file:///tmp/flink-checkpoints-directory
```
*docker-compose.yaml* uses the following:
```
...
    volumes:
      - ./conf:/opt/flink/conf
      - flink-checkpoint-directory:/tmp/flink-checkpoint-directory
      - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
...
volumes:
  flink-checkpoint-directory:
```

**Solution**:
```
    volumes:
      - ./conf:/opt/flink/conf
      - flink-checkpoints-directory:/tmp/flink-checkpoints-directory
      - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
...
volumes:
  flink-checkpoints-directory:
```
