### PR TITLE
Add subnet setting for Proxy user

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -71,3 +71,11 @@ services:
       - 9094:9094
 volumes:
   flink-checkpoints-directory:
+  
+networks:
+  default:
+    driver: bridge
+    ipam:
+      driver: default
+      config:
+      - subnet: 172.18.0.1/16


### PR DESCRIPTION
By default, Docker use `172.17.0.0/16` to `docker0` interface.  like:  
```
docker0   Link encap:Ethernet  HWaddr 02:42:91:7b:0f:21  
          inet addr:172.17.0.1  Bcast:172.17.255.255  Mask:255.255.0.0
```
and by default, Docker-compose will use `172.18.0.0/16`, `172.19.0.0/16` ...and so on, to new Bridge, like:  
```
br-c401dc9ce9fd Link encap:Ethernet  HWaddr 02:42:ac:c9:28:9e  
          inet addr:172.18.0.1  Bcast:172.18.255.255  Mask:255.255.0.0
```
But, My environment have proxy endpoint: `172.18.22.221`,  if can not setting subnet of docker-compose, the default subnet adderess will conflict with my Proxy, which cause it can not work.   

so, add subnet setting is meaningful for Proxy user : )