### PR TITLE
[hotfix] Minor issues with the English in the operations-playground README

### DIFF
--- a/operations-playground/README.md
+++ b/operations-playground/README.md
@@ -1,16 +1,16 @@
 # Flink Operations Playground
 
-The Flink operations playground let's you explore and play with [Apache Flink](https://flink.apache.org)'s features to manage and operate stream processing jobs, including
+The Flink operations playground lets you explore and play with [Apache Flink](https://flink.apache.org)'s features to manage and operate stream processing jobs, including
 
 * Observing automatic failure recovery of an application
 * Upgrading and rescaling an application
 * Querying the runtime metrics of an application
 
-It is based on a [docker-compose](https://docs.docker.com/compose/) environment and super easy to setup.
+It's based on a [docker-compose](https://docs.docker.com/compose/) environment and is super easy to setup.
 
 ## Setup
 
-The operations playground requires a custom Docker image in addition to public images for Flink, Kafka, and ZooKeeper. 
+The operations playground requires a custom Docker image, as well as public images for Flink, Kafka, and ZooKeeper. 
 
 The `docker-compose.yaml` file of the operations playground is located in the `operations-playground` directory. Assuming you are at the root directory of the [`flink-playgrounds`](https://github.com/apache/flink-playgrounds) repository, change to the `operations-playground` folder by running
 
@@ -34,7 +34,7 @@ Once you built the Docker image, run the following command to start the playgrou
 docker-compose up -d
 ```
 
-You can check if the playground was successfully started, if you can access the WebUI of the Flink cluster at [http://localhost:8081](http://localhost:8081).
+You can check if the playground was successfully started by accessing the WebUI of the Flink cluster at [http://localhost:8081](http://localhost:8081).
 
 ### Stopping the Playground
 


### PR DESCRIPTION
Some grammatical fixes for the README for the operations-playground.