### PR TITLE
[FLINK-16540] Fully specify bugfix version of Flink images in docker-compose.yaml

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     depends_on:
       - kafka
   jobmanager:
-    image: flink:1.10-scala_2.11
+    image: flink:1.10.0-scala_2.11
     command: "jobmanager.sh start-foreground"
     ports:
       - 8081:8081
@@ -46,7 +46,7 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: flink:1.10-scala_2.11
+    image: flink:1.10.0-scala_2.11
     depends_on:
       - jobmanager
     command: "taskmanager.sh start-foreground"


### PR DESCRIPTION
Fixes the bugfix version of the Flink images in the docker-compose.yaml.
This ensures that the Flink version in the custom built image and the Flink container that execute the program are exactly the same.

If merged, the change should also be applied to the `release-1.9` branch.