### PR TITLE
Added a guide for Windows users.

### DIFF
--- a/operations-playground/README.md
+++ b/operations-playground/README.md
@@ -36,6 +36,11 @@ docker-compose up -d
 
 You can check if the playground was successfully started by accessing the WebUI of the Flink cluster at [http://localhost:8081](http://localhost:8081).
 
+** for Windows Users **
+
+If you get the error "Unhandled exception: Filesharing has been cancelled", you should configure the file sharing in Docker Desktop before starting.
+In Settings > Resources > File Sharing, add the operations-playground/conf directory.
+
 ### Stopping the Playground
 
 To stop the playground, run the following command

--- a/operations-playground/README.md
+++ b/operations-playground/README.md
@@ -36,7 +36,7 @@ docker-compose up -d
 
 You can check if the playground was successfully started by accessing the WebUI of the Flink cluster at [http://localhost:8081](http://localhost:8081).
 
-** for Windows Users **
+#### for Windows Users
 
 If you get the error "Unhandled exception: Filesharing has been cancelled", you should configure the file sharing in Docker Desktop before starting.
 In Settings > Resources > File Sharing, add the operations-playground/conf directory.

--- a/operations-playground/README.md
+++ b/operations-playground/README.md
@@ -38,7 +38,7 @@ You can check if the playground was successfully started by accessing the WebUI 
 
 #### for Windows Users
 
-If you get the error "Unhandled exception: Filesharing has been cancelled", you should configure the file sharing in Docker Desktop before starting.
+If you get the error "Unhandled exception: Filesharing has been cancelled", you should configure file sharing in Docker Desktop before starting.
 In Settings > Resources > File Sharing, add the operations-playground/conf directory.
 
 ### Stopping the Playground


### PR DESCRIPTION
I tried to launch Playground on Windows and got the error "Unhandled exception: Filesharing has been cancelled".

As a result, I was able to solve it by the answer on this page (https://stackoverflow.com/questions/60754297/docker-compose-failed-to-build-filesharing-has-been-cancelled), but I think it would be better to write it inREAMDE.md.
