### PR TITLE
[hotfix] Remove parallelism setting to align with instructions

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -21,7 +21,7 @@ services:
   client:
     build: ../docker/ops-playground-image
     image: apache/flink-ops-playground:1-FLINK-1.11-scala_2.11
-    command: "flink run -d -p 2 /opt/ClickCountJob.jar --bootstrap.servers kafka:9092 --checkpointing --event-time"
+    command: "flink run -d /opt/ClickCountJob.jar --bootstrap.servers kafka:9092 --checkpointing --event-time"
     depends_on:
       - jobmanager
       - kafka


### PR DESCRIPTION
This change removes parallelism of 2 from the docker-compose file. Section "Step 2a: Restart Job without Changes" of the playground instructions implies that the job will be restarted with no changes. However, proposed restart commands use the default parallelism of 1. This contradicts the intention of not introducing any changes during the restart as it causes an implicit reduction of parallelism.