### PR TITLE
[FLINK-23100] update pyflink-walkthrough playground for Flink 1.13

### DIFF
--- a/pyflink-walkthrough/Dockerfile
+++ b/pyflink-walkthrough/Dockerfile
@@ -20,8 +20,8 @@
 # Build PyFlink Playground Image
 ###############################################################################
 
-FROM apache/flink:1.12.1-scala_2.11-java8
-ARG FLINK_VERSION=1.12.1
+FROM apache/flink:1.13.1-scala_2.12-java8
+ARG FLINK_VERSION=1.13.1
 
 # Install pyflink
 RUN set -ex; \
@@ -33,14 +33,14 @@ RUN set -ex; \
   ln -s /usr/bin/pip3 /usr/bin/pip; \
   apt-get update; \
   python -m pip install --upgrade pip; \
-  pip install apache-flink==1.12.1; \
+  pip install apache-flink==1.13.1; \
   pip install kafka-python;
 
 
 # Download connector libraries
 RUN wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-json/${FLINK_VERSION}/flink-json-${FLINK_VERSION}.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.11/${FLINK_VERSION}/flink-sql-connector-kafka_2.11-${FLINK_VERSION}.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.11/${FLINK_VERSION}/flink-sql-connector-elasticsearch7_2.11-${FLINK_VERSION}.jar;
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/${FLINK_VERSION}/flink-sql-connector-kafka_2.12-${FLINK_VERSION}.jar; \
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-elasticsearch7_2.12/${FLINK_VERSION}/flink-sql-connector-elasticsearch7_2.12-${FLINK_VERSION}.jar;
 
 
 RUN echo "taskmanager.memory.jvm-metaspace.size: 512m" >> /opt/flink/conf/flink-conf.yaml;

--- a/pyflink-walkthrough/README.md
+++ b/pyflink-walkthrough/README.md
@@ -5,7 +5,7 @@
 In this playground, you will learn how to build and run an end-to-end PyFlink pipeline for data analytics, covering the following steps:
 
 * Reading data from a Kafka source;
-* Creating data using a [UDF](https://ci.apache.org/projects/flink/flink-docs-release-1.12/dev/python/table-api-users-guide/udfs/python_udfs.html);
+* Creating data using a [UDF](https://ci.apache.org/projects/flink/flink-docs-release-1.13/dev/python/table-api-users-guide/udfs/python_udfs.html);
 * Performing a simple aggregation over the source data;
 * Writing the results to Elasticsearch and visualizing them in Kibana.
 

--- a/pyflink-walkthrough/docker-compose.yml
+++ b/pyflink-walkthrough/docker-compose.yml
@@ -20,7 +20,7 @@ version: '2.1'
 services:
   jobmanager:
     build: .
-    image: pyflink/pyflink:1.12.1-scala_2.11
+    image: pyflink/pyflink:1.13.1-scala_2.12
     volumes:
       - .:/opt/pyflink-walkthrough
     hostname: "jobmanager"
@@ -32,7 +32,7 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: pyflink/pyflink:1.12.1-scala_2.11
+    image: pyflink/pyflink:1.13.1-scala_2.12
     volumes:
     - .:/opt/pyflink-walkthrough
     expose:
@@ -52,7 +52,7 @@ services:
   kafka:
     image: wurstmeister/kafka:2.12-2.2.1
     ports:
-      - "9092"
+      - "9092:9092"
     depends_on:
       - zookeeper
     environment:


### PR DESCRIPTION
Straightforward update to Flink 1.13.1.

Only surprise was the need to update the Kafka port specification from "9092" to "9092:9092". See https://github.com/wurstmeister/kafka-docker/issues/211#issuecomment-334755757 for details.