### PR TITLE
update to an amd64 arch flink image

### DIFF
--- a/docker/ops-playground-image/Dockerfile
+++ b/docker/ops-playground-image/Dockerfile
@@ -32,7 +32,7 @@ RUN mvn clean install
 # Build Operations Playground Image
 ###############################################################################
 
-FROM apache/flink:1.13.1-scala_2.12-java8
+FROM apache/flink:1.13.2-scala_2.12-java8
 
 WORKDIR /opt/flink/bin
 

--- a/docker/ops-playground-image/java/flink-playground-clickcountjob/pom.xml
+++ b/docker/ops-playground-image/java/flink-playground-clickcountjob/pom.xml
@@ -44,7 +44,7 @@ under the License.
 
     <properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.13.1</flink.version>
+		<flink.version>1.13.2</flink.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>

--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -35,7 +35,7 @@ services:
     depends_on:
       - kafka
   jobmanager:
-    image: apache/flink:1.13.1-scala_2.12-java8
+    image: apache/flink:1.13.2-scala_2.12-java8
     command: "jobmanager.sh start-foreground"
     ports:
       - 8081:8081
@@ -46,7 +46,7 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: apache/flink:1.13.1-scala_2.12-java8
+    image: apache/flink:1.13.2-scala_2.12-java8
     depends_on:
       - jobmanager
     command: "taskmanager.sh start-foreground"

--- a/pyflink-walkthrough/Dockerfile
+++ b/pyflink-walkthrough/Dockerfile
@@ -20,20 +20,19 @@
 # Build PyFlink Playground Image
 ###############################################################################
 
-FROM apache/flink:1.13.1-scala_2.12-java8
-ARG FLINK_VERSION=1.13.1
+FROM apache/flink:1.13.2-scala_2.12-java8
+ARG FLINK_VERSION=1.13.2
 
 # Install pyflink
 RUN set -ex; \
   apt-get update; \
-  apt-get -y install python3; \
   apt-get -y install python3-pip; \
   apt-get -y install python3-dev; \
   ln -s /usr/bin/python3 /usr/bin/python; \
   ln -s /usr/bin/pip3 /usr/bin/pip; \
   apt-get update; \
   python -m pip install --upgrade pip; \
-  pip install apache-flink==1.13.1; \
+  pip install apache-flink==1.13.2; \
   pip install kafka-python;
 
 

--- a/pyflink-walkthrough/docker-compose.yml
+++ b/pyflink-walkthrough/docker-compose.yml
@@ -20,7 +20,7 @@ version: '2.1'
 services:
   jobmanager:
     build: .
-    image: pyflink/pyflink:1.13.1-scala_2.12
+    image: pyflink/pyflink:1.13.2-scala_2.12
     volumes:
       - .:/opt/pyflink-walkthrough
     hostname: "jobmanager"
@@ -32,7 +32,7 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: pyflink/pyflink:1.13.1-scala_2.12
+    image: pyflink/pyflink:1.13.2-scala_2.12
     volumes:
     - .:/opt/pyflink-walkthrough
     expose:

--- a/table-walkthrough/Dockerfile
+++ b/table-walkthrough/Dockerfile
@@ -22,12 +22,12 @@ COPY ./pom.xml /opt/pom.xml
 COPY ./src /opt/src
 RUN cd /opt; mvn clean install -Dmaven.test.skip
 
-FROM apache/flink:1.13.1-scala_2.12-java8
+FROM apache/flink:1.13.2-scala_2.12-java8
 
 # Download connector libraries
-RUN wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.13.1/flink-sql-connector-kafka_2.12-1.13.1.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.13.1/flink-connector-jdbc_2.12-1.13.1.jar; \
-    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.13.1/flink-csv-1.13.1.jar; \
+RUN wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-sql-connector-kafka_2.12/1.13.2/flink-sql-connector-kafka_2.12-1.13.2.jar; \
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-connector-jdbc_2.12/1.13.2/flink-connector-jdbc_2.12-1.13.2.jar; \
+    wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/org/apache/flink/flink-csv/1.13.2/flink-csv-1.13.2.jar; \
     wget -P /opt/flink/lib/ https://repo.maven.apache.org/maven2/mysql/mysql-connector-java/8.0.19/mysql-connector-java-8.0.19.jar;
 
 COPY --from=builder /opt/target/spend-report-*.jar /opt/flink/usrlib/spend-report.jar

--- a/table-walkthrough/pom.xml
+++ b/table-walkthrough/pom.xml
@@ -30,7 +30,7 @@ under the License.
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.13.1</flink.version>
+		<flink.version>1.13.2</flink.version>
 		<java.version>1.8</java.version>
 		<scala.binary.version>2.12</scala.binary.version>
 		<maven.compiler.source>${java.version}</maven.compiler.source>


### PR DESCRIPTION
The apache/flink:1.13.1-scala_2.12-java8 is a linux/arm64 arch image,
To avoid pulling an arm64 arch image on amd64 arch platform, update to "apache/flink:1.13.2-scala_2.12-java8", which is a linux/amd64 arch image.