### PR TITLE
Adding a missing test dependency

### DIFF
--- a/table-walkthrough/pom.xml
+++ b/table-walkthrough/pom.xml
@@ -65,6 +65,12 @@ under the License.
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-table-planner_${scala.binary.version}</artifactId>
+            <version>${flink.version}</version>
+            <scope>provided</scope>
+        </dependency>
 
         <dependency>
             <groupId>org.apache.flink</groupId>


### PR DESCRIPTION
## Description
Without this dependency add, maven fails test with .  Adding this dependency allows the test to run correctly.

## Error
```
Tests in error: 
  testReport(org.apache.flink.playgrounds.spendreport.SpendReportTest): Could not find any factories that implement 'org.apache.flink.table.delegation.ExecutorFactory' in the classpath.
```
[Snapshot](https://imgur.com/a/QOEx5JE)

## Reproduce
- Checkout master
- `cd table-walkthrough && mvn test`