### PR TITLE
[FLINK-30446][flink-playgrounds]bump mysql version to 8.0.31 for table-walkthrough supporting more architectures

### DIFF
--- a/table-walkthrough/docker-compose.yml
+++ b/table-walkthrough/docker-compose.yml
@@ -67,7 +67,7 @@ services:
       depends_on:
         - kafka
   mysql:
-    image: mysql:8.0.19
+    image: mysql:8.0.31
     command: --default-authentication-plugin=mysql_native_password --secure_file_priv=/data
     environment:
       MYSQL_USER: "sql-demo"


### PR DESCRIPTION
Low priority, but it doesn't look like table-walkthrough spins up out of the box w/o a newer version of MySQL. Updated to a MySQL version that is built for arm64/v8 and amd64.