### PR TITLE
FLINK-30440 Updating operations playground to Flink 1.16

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/dependency-reduced-pom.xml
 **/*.iml
 .DS_Store
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,9 @@
 **/*.iml
 .DS_Store
 .vscode
+
+# Eclipse
+.project
+.classpath
+.settings/
+bin/

--- a/README.md
+++ b/README.md
@@ -22,4 +22,4 @@ Flink job. The playground is presented in detail in
 Apache Flink is an open source project of The Apache Software Foundation (ASF).
 
 Flink is distributed data processing framework with powerful stream and batch processing capabilities.
-Learn more about Flink at [http://flink.apache.org/](https://flink.apache.org/)
+Learn more about Flink at [https://flink.apache.org/](https://flink.apache.org/)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@ Currently, the following playgrounds are available:
 
 * The **Flink Operations Playground** (in the `operations-playground` folder) lets you explore and play with Flink's features to manage and operate stream processing jobs. You can witness how Flink recovers a job from a failure, upgrade and rescale a job, and query job metrics. The playground consists of a Flink cluster, a Kafka cluster and an example 
 Flink job. The playground is presented in detail in
-["Flink Operations Playground"](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/try-flink/flink-operations-playground), which is part of the _Try Flink_ section of the Flink documentation.
+["Flink Operations Playground"](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/try-flink/flink-operations-playground), which is part of the _Try Flink_ section of the Flink documentation.
 
-* The **Table Walkthrough** (in the `table-walkthrough` folder) shows how to use the Table API to build an analytics pipeline that reads streaming data from Kafka and writes results to MySQL, along with a real-time dashboard in Grafana. The walkthrough is presented in detail in ["Real Time Reporting with the Table API"](https://ci.apache.org/projects/flink/flink-docs-release-1.15/docs/try-flink/table_api), which is part of the _Try Flink_ section of the Flink documentation.
+* The **Table Walkthrough** (in the `table-walkthrough` folder) shows how to use the Table API to build an analytics pipeline that reads streaming data from Kafka and writes results to MySQL, along with a real-time dashboard in Grafana. The walkthrough is presented in detail in ["Real Time Reporting with the Table API"](https://ci.apache.org/projects/flink/flink-docs-release-1.16/docs/try-flink/table_api), which is part of the _Try Flink_ section of the Flink documentation.
 
 * The **PyFlink Walkthrough** (in the `pyflink-walkthrough` folder) provides a complete example that uses the Python API, and guides you through the steps needed to run and manage Pyflink Jobs. The pipeline used in this walkthrough reads data from Kafka, performs aggregations, and writes results to Elasticsearch that are visualized with Kibana. This walkthrough is presented in detail in the [pyflink-walkthrough README](pyflink-walkthrough).
 

--- a/docker/ops-playground-image/Dockerfile
+++ b/docker/ops-playground-image/Dockerfile
@@ -20,19 +20,19 @@
 # Build Click Count Job
 ###############################################################################
 
-FROM maven:3.8-jdk-8-slim AS builder
+FROM maven:3.8.6-eclipse-temurin-17 AS builder
 
 # Get Click Count job and compile it
 COPY ./java/flink-playground-clickcountjob /opt/flink-playground-clickcountjob
 WORKDIR /opt/flink-playground-clickcountjob
-RUN mvn clean install
+RUN mvn clean verify
 
 
 ###############################################################################
 # Build Operations Playground Image
 ###############################################################################
 
-FROM apache/flink:1.15.2-scala_2.12-java8
+FROM apache/flink:1.16.0-scala_2.12-java11
 
 WORKDIR /opt/flink/bin
 

--- a/docker/ops-playground-image/java/flink-playground-clickcountjob/pom.xml
+++ b/docker/ops-playground-image/java/flink-playground-clickcountjob/pom.xml
@@ -22,7 +22,7 @@ under the License.
 
 	<groupId>org.apache.flink</groupId>
 	<artifactId>flink-playground-clickcountjob</artifactId>
-	<version>1-FLINK-1.15_2.12</version>
+	<version>1-FLINK-1.16_2.12</version>
 
 	<name>flink-playground-clickcountjob</name>
 	<packaging>jar</packaging>
@@ -44,11 +44,10 @@ under the License.
 
     <properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<flink.version>1.15.2</flink.version>
-		<java.version>1.8</java.version>
+		<flink.version>1.16.0</flink.version>
+		<java.version>11</java.version>
 		<scala.binary.version>2.12</scala.binary.version>
-		<maven.compiler.source>${java.version}</maven.compiler.source>
-		<maven.compiler.target>${java.version}</maven.compiler.target>
+		<maven.compiler.release>${java.version}</maven.compiler.release>
 	</properties>
 
 	<dependencies>
@@ -98,11 +97,7 @@ under the License.
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>3.1</version>
-				<configuration>
-					<source>${java.version}</source>
-					<target>${java.version}</target>
-				</configuration>
+				<version>3.10.1</version>
 			</plugin>
 
 			<!-- We use the maven-shade plugin to create a fat jar that contains all necessary dependencies. -->

--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -20,7 +20,7 @@ version: "2.1"
 services:
   client:
     build: ../docker/ops-playground-image
-    image: apache/flink-ops-playground:1-FLINK-1.15-scala_2.12
+    image: apache/flink-ops-playground:1-FLINK-1.16-scala_2.12
     command: "flink run -d /opt/ClickCountJob.jar --bootstrap.servers kafka:9092 --checkpointing --event-time"
     depends_on:
       - jobmanager
@@ -30,12 +30,12 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   clickevent-generator:
-    image: apache/flink-ops-playground:1-FLINK-1.15-scala_2.12
+    image: apache/flink-ops-playground:1-FLINK-1.16-scala_2.12
     command: "java -classpath /opt/ClickCountJob.jar:/opt/flink/lib/* org.apache.flink.playgrounds.ops.clickcount.ClickEventGenerator --bootstrap.servers kafka:9092 --topic input"
     depends_on:
       - kafka
   jobmanager:
-    image: apache/flink:1.15.2-scala_2.12-java8
+    image: apache/flink:1.16.0-scala_2.12-java11
     command: "jobmanager.sh start-foreground"
     ports:
       - 8081:8081
@@ -46,7 +46,7 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
-    image: apache/flink:1.15.2-scala_2.12-java8
+    image: apache/flink:1.16.0-scala_2.12-java11
     depends_on:
       - jobmanager
     command: "taskmanager.sh start-foreground"


### PR DESCRIPTION
I also used the opportunity and updated that data generator to Java 11. I verified I can see the output of the job (on the "output" Kafka topic) after the update.