### PR TITLE
[FLINK-31228] Update kafka and zookeeper docker image

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -57,16 +57,17 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
-  kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: bitnami/zookeeper:3.7.1
     environment:
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
-      KAFKA_CREATE_TOPICS: "input:2:1, output:2:1"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    ports:
-      - 9092:9092
-      - 9094:9094
+      - ALLOW_ANONYMOUS_LOGIN=yes
+  kafka:
+    image: bitnami/kafka:3.4
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CLIENT:PLAINTEXT,EXTERNAL:PLAINTEXT
+      - KAFKA_CFG_LISTENERS=CLIENT://:9092,EXTERNAL://:9094
+      - KAFKA_CFG_ADVERTISED_LISTENERS=CLIENT://kafka:9092,EXTERNAL://localhost:9094
+      - KAFKA_CFG_INTER_BROKER_LISTENER_NAME=CLIENT
+    depends_on:
+      - zookeeper

--- a/pyflink-walkthrough/docker-compose.yml
+++ b/pyflink-walkthrough/docker-compose.yml
@@ -46,30 +46,31 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: bitnami/zookeeper:3.7.1
     ulimits:
       nofile:
         soft: 65536
         hard: 65536
     ports:
       - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: bitnami/kafka:3.4
     ports:
       - "9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
       - zookeeper
-    environment:
-      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "payment_msg:1:1"
   generator:
     build: generator
     image: generator:1.0
     depends_on:
       - kafka
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.8.0
+    image: elasticsearch:7.8.0
     environment:
       - cluster.name=docker-cluster
       - bootstrap.memory_lock=true
@@ -86,7 +87,7 @@ services:
         soft: 65536
         hard: 65536
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.8.0
+    image: kibana:7.8.0
     ports:
       - "5601:5601"
     depends_on:

--- a/table-walkthrough/docker-compose.yml
+++ b/table-walkthrough/docker-compose.yml
@@ -46,21 +46,20 @@ services:
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
+    image: bitnami/zookeeper:3.7.1
     ports:
       - "2181:2181"
+    environment:
+      - ALLOW_ANONYMOUS_LOGIN=yes
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: bitnami/kafka:3.4
     ports:
       - "9092:9092"
+    environment:
+      - KAFKA_CFG_ZOOKEEPER_CONNECT=zookeeper:2181
+      - ALLOW_PLAINTEXT_LISTENER=yes
     depends_on:
       - zookeeper
-    environment:
-      KAFKA_ADVERTISED_HOST_NAME: "kafka"
-      KAFKA_ADVERTISED_PORT: "9092"
-      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "kafka:1:1"
   data-generator:
       image: apache/data-generator:1
       build: ../docker/data-generator


### PR DESCRIPTION
As reported in [FLINK-31228](https://issues.apache.org/jira/browse/FLINK-31228) and [issue#734](https://github.com/wurstmeister/kafka-docker/issues/734), the zookeeper image maintained by `wurstmeister` is buggy.  And it is also not well documented.

On the other hand, docker images from `bitnami` are updated frequently, and they are well documented. So I think we need to switch to bitnami.

In addition, since both `elasticsearch` and `kibana` are available on official Hub, there is no need to use docker.elastic.co.

I have conducted all tests in my computer on updated code. 