### PR TITLE
Create flink_data volume for operations playground.

### DIFF
--- a/operations-playground/README.md
+++ b/operations-playground/README.md
@@ -26,15 +26,6 @@ Build the Docker image by running
 docker-compose build
 ```
 
-### Preparing the Checkpoint and Savepoint Directories
-
-Create the checkpoint and savepoint directories on the Docker host machine (these volumes are mounted by the jobmanager and taskmanager, as specified in docker-compose.yaml):
-
-```bash
-mkdir -p /tmp/flink-checkpoints-directory
-mkdir -p /tmp/flink-savepoints-directory
-```
-
 ### Starting the Playground
 
 Once you built the Docker image, run the following command to start the playground

--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -27,6 +27,7 @@ services:
       - kafka
     volumes:
       - ./conf:/opt/flink/conf
+      - flink_data:/tmp/
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   clickevent-generator:

--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -41,8 +41,7 @@ services:
       - 8081:8081
     volumes:
       - ./conf:/opt/flink/conf
-      - /tmp/flink-checkpoints-directory:/tmp/flink-checkpoints-directory
-      - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
+      - flink_data:/tmp/
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   taskmanager:
@@ -52,8 +51,7 @@ services:
     command: "taskmanager.sh start-foreground"
     volumes:
       - ./conf:/opt/flink/conf
-      - /tmp/flink-checkpoints-directory:/tmp/flink-checkpoints-directory
-      - /tmp/flink-savepoints-directory:/tmp/flink-savepoints-directory
+      - flink_data:/tmp/
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
   zookeeper:
@@ -70,3 +68,5 @@ services:
     ports:
       - 9092:9092
       - 9094:9094
+volumes:
+  flink_data:


### PR DESCRIPTION
With this change, users will not have to create and permission flink job directories. This is the preferred method of persisting data generated by the docker container. More here:

https://docs.docker.com/storage/volumes/

i.e. removing this setup step
```bash
mkdir -p /tmp/flink-checkpoints-directory
mkdir -p /tmp/flink-savepoints-directory
```