### PR TITLE
Fix docker compose configuration

### DIFF
--- a/operations-playground/docker-compose.yaml
+++ b/operations-playground/docker-compose.yaml
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-version: "2.1"
 services:
   client:
     build: ../docker/ops-playground-image
@@ -55,19 +54,15 @@ services:
       - flink_data:/tmp/
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
-  zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
+    image: 'bitnami/kafka:3.9.0'
     environment:
-      KAFKA_ADVERTISED_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENERS: INSIDE://:9092,OUTSIDE://:9094
-      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: INSIDE:PLAINTEXT,OUTSIDE:PLAINTEXT
-      KAFKA_INTER_BROKER_LISTENER_NAME: INSIDE
-      KAFKA_CREATE_TOPICS: "input:2:1, output:2:1"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-    ports:
-      - 9092:9092
-      - 9094:9094
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_NUM_PARTITIONS=2
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
 volumes:
   flink_data:

--- a/pyflink-walkthrough/docker-compose.yml
+++ b/pyflink-walkthrough/docker-compose.yml
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-version: '2.1'
 services:
   jobmanager:
     build: .
@@ -45,24 +44,15 @@ services:
       - jobmanager:jobmanager
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
-  zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
-    ulimits:
-      nofile:
-        soft: 65536
-        hard: 65536
-    ports:
-      - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
-    ports:
-      - "9092:9092"
-    depends_on:
-      - zookeeper
+    image: 'bitnami/kafka:3.9.0'
     environment:
-      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "payment_msg:1:1"
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
   generator:
     build: generator
     image: generator:1.0

--- a/table-walkthrough/docker-compose.yml
+++ b/table-walkthrough/docker-compose.yml
@@ -16,7 +16,6 @@
 # limitations under the License.
 ################################################################################
 
-version: '2.1'
 services:
   jobmanager:
     image: apache/flink-table-walkthrough:1-FLINK-1.16-scala_2.12
@@ -45,22 +44,15 @@ services:
       - jobmanager:jobmanager
     environment:
       - JOB_MANAGER_RPC_ADDRESS=jobmanager
-  zookeeper:
-    image: wurstmeister/zookeeper:3.4.6
-    ports:
-      - "2181:2181"
   kafka:
-    image: wurstmeister/kafka:2.13-2.8.1
-    ports:
-      - "9092:9092"
-    depends_on:
-      - zookeeper
+    image: 'bitnami/kafka:3.9.0'
     environment:
-      KAFKA_ADVERTISED_HOST_NAME: "kafka"
-      KAFKA_ADVERTISED_PORT: "9092"
-      HOSTNAME_COMMAND: "route -n | awk '/UG[ \t]/{print $$2}'"
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "kafka:1:1"
+      - KAFKA_CFG_NODE_ID=0
+      - KAFKA_CFG_PROCESS_ROLES=controller,broker
+      - KAFKA_CFG_LISTENERS=PLAINTEXT://:9092,CONTROLLER://:9093
+      - KAFKA_CFG_LISTENER_SECURITY_PROTOCOL_MAP=CONTROLLER:PLAINTEXT,PLAINTEXT:PLAINTEXT
+      - KAFKA_CFG_CONTROLLER_QUORUM_VOTERS=0@kafka:9093
+      - KAFKA_CFG_CONTROLLER_LISTENER_NAMES=CONTROLLER
   data-generator:
       image: apache/data-generator:1
       build: ../docker/data-generator


### PR DESCRIPTION
Current configuration does not work, when i run with `docker-compose up -d` then get:

> [DEPRECATION NOTICE] Docker Image Format v1 and Docker Image manifest version 2, schema 1 support is disabled by default and will be removed in an upcoming release. Suggest the author of docker.io/wurstmeister/zookeeper:3.4.6 to upgrade the image to the OCI Format or Docker Image manifest v2, schema 2. More information at https://docs.docker.com/go/deprecated-image-specs/

The last push of "wurstmeister/zookeeper" was 6 years ago, and Kafka kraft mode was stabled, i removed the zookeeper service for simplicity and use "bitnami/kafka" instead. 

The top level version is obsolete, the warning is annoying:

> WARN[0000] ... the attribute `version` is obsolete, it will be ignored, please remove it to avoid potential confusion 

So i removed it too. 

I have tested with instructions from both:

1. https://nightlies.apache.org/flink/flink-docs-release-1.20/docs/try-flink/table_api/
2. https://nightlies.apache.org/flink/flink-docs-master/docs/try-flink/flink-operations-playground/
3. https://github.com/apache/flink-playgrounds/blob/master/pyflink-walkthrough/README.md




